### PR TITLE
Improve UI and add dark/light mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,18 @@ const App: React.FC = () => {
     }
   );
 
+  const [theme, setTheme] = useState<string>(
+    localStorage.getItem("theme") ||
+    (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+  );
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => prev === "dark" ? "light" : "dark");
+
   useEffect(() => {
     if (status.apple === 200) {
       fetchPlaylists("apple");
@@ -215,7 +227,7 @@ const App: React.FC = () => {
 
   return (
     <div>
-      <nav className="bg-black top-0 flex pt-24 items-center padding-1 justifyc-space padding-lr-2">
+      <nav className="app-bar">
         <div className="flex left-flex-comp"></div>
         <div className="container flex flex-row">
           <div className="flex flex-row items-center" id="hamburger">
@@ -230,7 +242,10 @@ const App: React.FC = () => {
             {/* <a href="#">Dashboard</a> */}
           </div>
         </div>
-        <div className="flex right-flex-comp">
+        <div className="flex right-flex-comp" style={{ gap: "1rem" }}>
+          <button className="theme-toggle" onClick={toggleTheme}>
+            {theme === "dark" ? "Light" : "Dark"}
+          </button>
           <Account />
         </div>
       </nav>

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -1,24 +1,4 @@
-/* :root {
-  --bg: #f6f6f7;
-  --cardBG: #fff;
-  --text: #141414;
-  --cardShadow: rgba(0, 0, 0, .07);
-} */
-
-/* @media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0f1111;
-    --cardBG: #1b1e1e;
-    --text: #e2e2e2;
-    --cardShadow: rgba(0, 0, 0, .4);
-  }
-} */
-
-/* body,
-html {
-  background: var(--bg);
-  color: var(--text);
-} */
+/* utilities */
 
 body,
 html {
@@ -40,10 +20,7 @@ html {
 
   display: flex;
   flex-direction: column;
-
-  background-color: light-dark(#1b1e1e, #1b1e1e);
-
-  color-scheme: light dark;
+  background-color: var(--bg-color);
 }
 
 h1 {
@@ -115,8 +92,20 @@ h1 {
 }
 
 .bg-black {
-  /* background-color: light-dark(#fff, #000); */
-  background-color: #000;
+  background-color: var(--card-bg);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.app-bar {
+  background-color: var(--card-bg);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
 }
 
 .fixed {
@@ -159,7 +148,7 @@ a {
   justify-self: center;
   vertical-align: top;
 
-  color: light-dark(#91a4a4, #91a4a4);
+  color: var(--accent-color);
 }
 
 .h-i {
@@ -322,7 +311,9 @@ a {
 }
 
 .playlist-section {
-  background-color: light-dark(#1b1e1e, #1b1e1e);
+  background-color: var(--card-bg);
+  border-radius: 8px;
+  padding: 1rem;
 }
 
 .white {
@@ -339,4 +330,13 @@ a {
 
 .margin-left-auto {
   margin-left: auto;
+}
+
+.theme-toggle {
+  background-color: var(--card-bg);
+  color: var(--text-color);
+  border: 1px solid var(--accent-color);
+  padding: 0.25rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
 }

--- a/src/css/PlaylistCollection.css
+++ b/src/css/PlaylistCollection.css
@@ -1,16 +1,14 @@
 /* PlaylistCollection.css */
 .playlist-collection {
   display: grid;
-  /* grid-template-columns: repeat(auto-fit, minmax(8vw, 1fr)); */
-  grid-template-columns: repeat(5, minmax(8vw, 1fr));
-
-  gap: 12px;
-  /* padding: 12px; */
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 16px;
+  padding: 0.5rem;
 }
 
 @media (max-width:640px) {
   .playlist-collection {
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
   }
 
   .provider-header {

--- a/src/css/PlaylistComponent.css
+++ b/src/css/PlaylistComponent.css
@@ -5,7 +5,7 @@
   text-align: center;
   padding: 14px;
   border-radius: 8px;
-  background-color: #f8f8f8;
+  background-color: var(--card-bg);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s ease-in-out;
 
@@ -41,12 +41,13 @@
 .playlist-title {
   font-size: 1.2rem;
   margin: 0;
-  color: light-dark(black, #f8f8f8);
+  color: var(--text-color);
 }
 
 .playlist-song-count {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--text-color);
+  opacity: 0.7;
 }
 
 .spotify-gradient {

--- a/src/index.css
+++ b/src/index.css
@@ -3,14 +3,27 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  /* default (light) theme */
+  --bg-color: #f0f2f5;
+  --text-color: #212529;
+  --card-bg: #ffffff;
+  --accent-color: #646cff;
+  color-scheme: light;
+  color: var(--text-color);
+  background-color: var(--bg-color);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+[data-theme="dark"] {
+  --bg-color: #1b1e1e;
+  --text-color: #e9e9e9;
+  --card-bg: #272727;
+  --accent-color: #8d8dff;
+  color-scheme: dark;
 }
 
 a,
@@ -19,7 +32,7 @@ a,
   font-weight: 500 !important;
   font-size: 24px !important;
 
-  color: #646cff !important;
+  color: var(--accent-color) !important;
 
   text-decoration: inherit !important;
   text-transform: none !important;
@@ -39,6 +52,8 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
 h1 {
@@ -47,11 +62,12 @@ h1 {
 }
 
 h2 {
-  color: light-dark(white, black);
+  color: var(--text-color);
 }
 
 p {
-  color: light-dark(rgb(119, 119, 119), black);
+  color: var(--text-color);
+  opacity: 0.8;
 }
 
 button {
@@ -61,13 +77,14 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--card-bg);
+  color: var(--text-color);
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.25s, border-color 0.25s;
 }
 
 button:hover {
-  border-color: #646cff;
+  border-color: var(--accent-color);
 }
 
 button:focus,
@@ -75,20 +92,6 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-
-  a:hover {
-    color: #747bff;
-  }
-
-  button {
-    background-color: #f9f9f9;
-  }
-}
 
 
 


### PR DESCRIPTION
## Summary
- overhaul root styles to use CSS variables for light/dark themes
- create sticky `app-bar` navigation with theme toggle button
- modernize playlist components and collections with variable based colors and responsive grid

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS6305 Output file has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_68536c7cbb548329aba6dcfd3a7c2f63