### PR TITLE
Refactor platform clients and playlist flow

### DIFF
--- a/src/components/PlaylistComponent.tsx
+++ b/src/components/PlaylistComponent.tsx
@@ -29,11 +29,18 @@ const PlaylistComponent: React.FC<PlaylistComponentProps> = ({
       onRemove({ id, name, image, trackCount, description, isPublic, href, platform, owner: "", status });
   };
 
+  const handleDoubleClick = () => {
+    if (status !== state.PENDING && onAdd) {
+      onAdd({ id, name, image, trackCount, description, isPublic, href, platform, owner: "", status });
+    }
+  };
+
   return (
     <div
       ref={drag}
       className={`playlist-component ${platform}-gradient ${isDragging ? "opacity-50" : "opacity-100"}`}
       onClick={handleClick} // On click will opened detailed view, future feature
+      onDoubleClick={handleDoubleClick}
     >
       <div>
         <img

--- a/src/components/PlaylistSection.tsx
+++ b/src/components/PlaylistSection.tsx
@@ -1,67 +1,177 @@
-import React, { useState } from "react";
-import Button from '@mui/material/Button';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import PlaylistCollection from "./PlaylistCollection";
-import { Playlist } from "../types/playlist";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
 import { useDrop } from "react-dnd";
-import "../css/PlaylistSection.css";
 
+import PlaylistCollection from "./PlaylistCollection";
+import type { Playlist } from "../types/playlist";
 import Platform, { getPlatformLogo, getPlatformDisplayName } from "../types/platform";
 import { state } from "../types/status";
+import type { IPlatformClient } from "../data/clients/IPlatformClient";
 
-const loggedIn = !!localStorage.getItem("token");
+import "../css/PlaylistSection.css";
+
+const providerKey = (p: Platform): "apple" | "spotify" =>
+  p === Platform.APPLE_MUSIC ? "apple" : "spotify";
 
 interface Props {
   platform: Platform;
-  playlists: Playlist[];
-  lastUpdated?: Date | null;
-  onRefresh: () => void;
-  onAddToPending: (p: Playlist, destination: Platform) => void;
+  client: IPlatformClient | null;
+  demoPlaylists: Playlist[];
+  isDemoMode: boolean;
+  status: number;
+  onStatusChange: (status: number) => void;
+  onAddToPending: (playlist: Playlist, destination: Platform) => void;
+  hidePlaylists?: boolean;
   children?: React.ReactNode;
 }
 
 const PlaylistSection: React.FC<Props> = ({
   platform,
-  playlists,
-  lastUpdated,
-  onRefresh,
+  client,
+  demoPlaylists,
+  isDemoMode,
+  status,
+  onStatusChange,
   onAddToPending,
+  hidePlaylists = false,
   children,
 }) => {
   const [{ isOver, canDrop }, drop] = useDrop<Playlist, void, any>(() => ({
     accept: ["DRAG_FROM_PROVIDER"],
     canDrop: (pl) => pl.platform !== platform,
     drop: (pl) => onAddToPending(pl, platform),
-    collect: (m) => ({ isOver: m.isOver(), canDrop: m.canDrop() }),
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
+    }),
   }));
 
-  // Dropdown (MUI Menu) anchor + handlers
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
-  const handleOpen = (e: React.MouseEvent<HTMLElement>) => setAnchorEl(e.currentTarget);
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
-  const platforms = Object.values(Platform);
+  const platforms = useMemo(() => Object.values(Platform), []);
+
+  const [playlists, setPlaylists] = useState<Playlist[]>([]);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const hasBootstrappedRef = useRef(false);
+  const previousStatusRef = useRef(status);
+  const cacheKey = useMemo(() => `${providerKey(platform)}-playlists`, [platform]);
+
+  const isLoggedIn = !!localStorage.getItem("token");
+
+  const loadFromCache = useCallback(() => {
+    const cache = localStorage.getItem(cacheKey);
+    if (!cache) return false;
+
+    try {
+      const { items, lastUpdated: cachedLastUpdated } = JSON.parse(cache);
+      if (!cachedLastUpdated) return false;
+
+      const lastUpdatedDate = new Date(cachedLastUpdated);
+      const oneHourAgo = Date.now() - 1000 * 60 * 60;
+      if (lastUpdatedDate.getTime() < oneHourAgo) return false;
+
+      setPlaylists(items);
+      setLastUpdated(lastUpdatedDate);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [cacheKey]);
+
+  const deriveStatusCode = (err: unknown): number => {
+    if (typeof err === "number") return err;
+    if (typeof err === "object" && err && "status" in err) {
+      const statusCode = Number((err as { status?: number }).status);
+      return Number.isFinite(statusCode) ? statusCode : 500;
+    }
+    if (err instanceof Error) {
+      const match = err.message.match(/\b(4\d{2}|5\d{2})\b/);
+      if (match) return Number(match[0]);
+      if (/401/.test(err.message)) return 401;
+    }
+    return 500;
+  };
+
+  const fetchPlaylists = useCallback(async () => {
+    if (!client) return;
+    setIsRefreshing(true);
+    try {
+      const { items } = await client.getUserPlaylists({ limit: 50 });
+      setPlaylists(items);
+      const now = new Date();
+      setLastUpdated(now);
+      localStorage.setItem(
+        cacheKey,
+        JSON.stringify({ items, lastUpdated: now.toISOString() })
+      );
+      onStatusChange(200);
+    } catch (err) {
+      const statusCode = deriveStatusCode(err);
+      onStatusChange(statusCode);
+      console.error(`Failed to fetch playlists for ${platform}:`, err);
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [cacheKey, client, onStatusChange, platform]);
+
+  useEffect(() => {
+    hasBootstrappedRef.current = false;
+  }, [client, isDemoMode, cacheKey]);
+
+  useEffect(() => {
+    if (!isDemoMode) return;
+    setPlaylists(demoPlaylists.map((pl) => ({ ...pl })));
+    setLastUpdated(null);
+    onStatusChange(200);
+  }, [demoPlaylists, isDemoMode, onStatusChange]);
+
+  useEffect(() => {
+    if (isDemoMode || !client || hasBootstrappedRef.current) return;
+
+    const bootstrapped = loadFromCache();
+    hasBootstrappedRef.current = true;
+    if (!bootstrapped && status === 200) {
+      fetchPlaylists();
+    }
+  }, [client, fetchPlaylists, isDemoMode, loadFromCache, status]);
+
+  useEffect(() => {
+    if (isDemoMode || !client) return;
+    if (status === 200 && previousStatusRef.current !== 200) {
+      fetchPlaylists();
+    }
+    previousStatusRef.current = status;
+  }, [client, fetchPlaylists, isDemoMode, status]);
+
+  const displayPlaylists = hidePlaylists ? [] : playlists;
 
   return (
     <div ref={drop} className={`playlist-section ${isOver && canDrop ? "over" : ""} p-4`}>
       <header className="provider-header">
-        <div className="flex items-center gap-2 border-2 rounded-[8px] border-gray-300 pb-1 p-2 w-[100%] lg:w-[40%] justify-between cursor-pointer" onClick={handleOpen}>
+        <div
+          className="flex items-center gap-2 border-2 rounded-[8px] border-gray-300 pb-1 p-2 w-[100%] lg:w-[40%] justify-between cursor-pointer"
+          onClick={handleOpen}
+        >
           <div className="flex items-center gap-2">
-            <img src={getPlatformLogo(platform)}
+            <img
+              src={getPlatformLogo(platform)}
               alt={`${platform} logo`}
-              className="w-[50px] aspect-square p-0" />
+              className="w-[50px] aspect-square p-0"
+            />
 
             <h2 className="font-bold text-base lg:text-l text-nowrap">
               {getPlatformDisplayName(platform)}
             </h2>
           </div>
 
-          {/* Down Arrow */}
-          <div className="border-l-8 border-l-transparent border-r-8 border-r-transparent border-t-8">
-          </div>
+          <div className="border-l-8 border-l-transparent border-r-8 border-r-transparent border-t-8" />
         </div>
         <Menu
           id="platform-menu"
@@ -71,40 +181,50 @@ const PlaylistSection: React.FC<Props> = ({
           anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
           transformOrigin={{ vertical: "top", horizontal: "left" }}
         >
-          {platforms.map((p) => (p !== platform) && (
-            <MenuItem key={p} onClick={handleClose}>
-              <ListItemIcon>
-                <img src={getPlatformLogo(p as Platform)} alt={`${p} logo`} className="w-6 h-6" />
-              </ListItemIcon>
-              <ListItemText>{getPlatformDisplayName(p as Platform)}</ListItemText>
-            </MenuItem>
-          )
+          {platforms.map(
+            (p) =>
+              p !== platform && (
+                <MenuItem key={p} onClick={handleClose}>
+                  <ListItemIcon>
+                    <img
+                      src={getPlatformLogo(p as Platform)}
+                      alt={`${p} logo`}
+                      className="w-6 h-6"
+                    />
+                  </ListItemIcon>
+                  <ListItemText>{getPlatformDisplayName(p as Platform)}</ListItemText>
+                </MenuItem>
+              )
           )}
         </Menu>
 
-
-        <div className="flex flex-column ml-auto">
+        <div className="flex flex-column ml-auto text-right">
           {lastUpdated && (
-            <small className="align-center text-left ml-auto" >
-              Last updated: {""} <br />
+            <small className="align-center text-left ml-auto">
+              Last updated: <br />
               {lastUpdated.toLocaleString()}
             </small>
           )}
 
-          {loggedIn && (
-            <Button variant="outlined" size="small" fullWidth={false} onClick={onRefresh}>
-              Refresh
+          {isLoggedIn && !isDemoMode && (
+            <Button
+              variant="outlined"
+              size="small"
+              fullWidth={false}
+              onClick={fetchPlaylists}
+              disabled={isRefreshing}
+            >
+              {isRefreshing ? "Refreshing..." : "Refresh"}
             </Button>
           )}
         </div>
-
       </header>
 
       <PlaylistCollection
-        playlists={playlists}
+        playlists={displayPlaylists}
         status={state.PENDING}
         onAdd={(pl) => onAddToPending(pl, platform)}
-        onRemove={() => { }}
+        onRemove={() => undefined}
       />
       {children}
     </div>
@@ -112,3 +232,4 @@ const PlaylistSection: React.FC<Props> = ({
 };
 
 export default PlaylistSection;
+

--- a/src/data/clients/AppleMusicClient.ts
+++ b/src/data/clients/AppleMusicClient.ts
@@ -6,27 +6,20 @@ import type { Track } from "../../types/track";
 
 export class AppleMusicClient implements IPlatformClient {
     readonly platform = Platform.APPLE_MUSIC;
-    private token: string = "";
 
-    setToken(token: string) { this.token = token; };
-    private get headers() {
-        return {
-            Authorization: `Bearer ${this.token}`,
-            "Content-Type": "application/json"
-        };
-    };
+    setToken(_token: string) { /* Apple Music client token handling pending implementation */ };
 
     async getCurrentUser() {
         // TODO: Implement Apple Music user retrieval
         return { id: "apple_user", name: "Apple Music User" };
     }
 
-    async getUserPlaylists(opts?: { offset?: string; limit?: number }) {
+    async getUserPlaylists(_opts?: { offset?: string; limit?: number }) {
         // TODO: Implement Apple Music playlist retrieval
         return { items: [], next: false };
     }
 
-    async createPlaylist(name: string, opts?: { description?: string; public?: boolean }) {
+    async createPlaylist(name: string, opts?: { description?: string; isPublic?: boolean; image?: string }) {
         //TODO: Implement Apple Music playlist creation
         const playlist: Playlist = {
             id: "new_apple_playlist",
@@ -34,24 +27,24 @@ export class AppleMusicClient implements IPlatformClient {
             name: name,
             owner: "Apple Music User",
             trackCount: 0,
-            isPublic: opts?.public ?? false,
+            isPublic: opts?.isPublic ?? false,
             href: "",
             status: state.SUCCESS
         };
         return playlist;
     }
 
-    async addTracksToPlaylist(playlistId: string, tracks: Track[]) {
+    async addTracksToPlaylist(_playlistId: string, _tracks: Track[]) {
         // TODO: Implement Apple Music add tracks to playlist
         return;
     }
 
-    async getPlaylistTracks(playlistId: string, opts?: { cursor?: string; limit?: number }) {
+    async getPlaylistTracks(_playlistId: string, _opts?: { cursor?: string; limit?: number }) {
         // TODO: Implement Apple Music playlist tracks retrieval
         return { items: [], next: false };
     }
 
-    async searchTrackByISRC(isrc: string, opts: { limit?: number; }) {
+    async searchTrackByISRC(_isrc: string, _opts: { limit?: number; } = {}) {
         return [];
     }
 

--- a/src/data/clients/IPlatformClient.ts
+++ b/src/data/clients/IPlatformClient.ts
@@ -23,7 +23,7 @@ export interface IPlatformClient {
     ): Promise<
         {
             items: Playlist[];
-            next?: Boolean;
+            next?: boolean;
         }
     >;
 
@@ -34,7 +34,7 @@ export interface IPlatformClient {
     ): Promise<
         {
             items: Track[];
-            next?: Boolean;
+            next?: boolean;
         }
     >;
 

--- a/src/handler/IPlatformOAuthClient.ts
+++ b/src/handler/IPlatformOAuthClient.ts
@@ -1,0 +1,5 @@
+export interface IPlatformOAuthClient {
+  redirectToOAuth(): Promise<void>;
+  handleCallback(): Promise<void>;
+}
+

--- a/src/handler/appleAPI.ts
+++ b/src/handler/appleAPI.ts
@@ -1,52 +1,62 @@
 import { API_FULL_URL, APP_FULL_URL } from "../config";
+import type { IPlatformOAuthClient } from "./IPlatformOAuthClient";
+
 declare const MusicKit: any;
 
 interface AppleMusicConfig {
-    developerToken: string;
-    app: {
-        name: string;
-        build: string;
-    };
+  developerToken: string;
+  app: {
+    name: string;
+    build: string;
+  };
 }
 
-async function redirectToOAuth(): Promise<void> {
+export class AppleMusicOAuthClient implements IPlatformOAuthClient {
+  async redirectToOAuth(): Promise<void> {
     try {
-        const fetchDevToken = await fetch(`${API_FULL_URL}/api/apple/devToken`, {
-            method: "GET",
-            mode: "cors",
-        });
+      const fetchDevToken = await fetch(`${API_FULL_URL}/api/apple/devToken`, {
+        method: "GET",
+        mode: "cors",
+      });
 
-        if (!fetchDevToken.ok)
-            return console.error("Failed to get developer token");
+      if (!fetchDevToken.ok) {
+        console.error("Failed to get developer token");
+        return;
+      }
 
-        const { developerToken } = await fetchDevToken.json();
-        const musicKitConfig: AppleMusicConfig = {
-            developerToken,
-            app: {
-                name: "SyncraSong",
-                build: "0.0.2"
-            },
-        };
-        await MusicKit.configure(musicKitConfig);
-        const musicInstance = MusicKit.getInstance();
-        await musicInstance.authorize();
-        const musicUserToken = await musicInstance.musicUserToken;
-        if (!musicUserToken)
-            return console.error("Failed to authorize with Apple Music");
+      const { developerToken } = await fetchDevToken.json();
+      const musicKitConfig: AppleMusicConfig = {
+        developerToken,
+        app: {
+          name: "SyncraSong",
+          build: "0.0.2",
+        },
+      };
 
-        window.location.href = `${APP_FULL_URL}/callback/apple?musicUserToken=${musicUserToken}`;
+      await MusicKit.configure(musicKitConfig);
+      const musicInstance = MusicKit.getInstance();
+      await musicInstance.authorize();
+      const musicUserToken = await musicInstance.musicUserToken;
+      if (!musicUserToken) {
+        console.error("Failed to authorize with Apple Music");
+        return;
+      }
+
+      window.location.href = `${APP_FULL_URL}/callback/apple?musicUserToken=${musicUserToken}`;
+    } catch (error) {
+      console.error("Error during Apple Music authorization:", error);
     }
-    catch (error) {
-        console.error("Error during Apple Music authorization:", error);
-    }
-}
+  }
 
-async function handleCallback(): Promise<void> {
+  async handleCallback(): Promise<void> {
     window.history.replaceState({}, document.title, "/");
-    return;
+  }
 }
 
-export {
-    redirectToOAuth as redirectToAppleOAuth,
-    handleCallback as handleAppleCallback
-}
+export const appleMusicOAuthClient = new AppleMusicOAuthClient();
+
+export const redirectToAppleOAuth = (): Promise<void> =>
+  appleMusicOAuthClient.redirectToOAuth();
+export const handleAppleCallback = (): Promise<void> =>
+  appleMusicOAuthClient.handleCallback();
+

--- a/src/handler/spotifyAPI.ts
+++ b/src/handler/spotifyAPI.ts
@@ -1,8 +1,10 @@
 import { APP_FULL_URL, SPOTIFY_CLIENT_ID, SPOTIFY_SCOPES } from "../config";
+import type { IPlatformOAuthClient } from "./IPlatformOAuthClient";
 
-async function redirectToOAuth(): Promise<void> {
-    const verifier = generateCodeVerifier(128);
-    const challenge = await generateCodeChallenge(verifier);
+export class SpotifyOAuthClient implements IPlatformOAuthClient {
+  async redirectToOAuth(): Promise<void> {
+    const verifier = this.generateCodeVerifier(128);
+    const challenge = await this.generateCodeChallenge(verifier);
 
     sessionStorage.setItem("spotify_verifier", verifier);
 
@@ -15,39 +17,40 @@ async function redirectToOAuth(): Promise<void> {
     params.append("code_challenge", challenge);
 
     document.location = `https://accounts.spotify.com/authorize?${params.toString()}`;
-}
+  }
 
-function generateCodeVerifier(length: number) {
-    let text = '';
-    let possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
-    for (let i = 0; i < length; i++)
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-
-    return text;
-}
-
-async function generateCodeChallenge(codeVerifier: string) {
-    const data = new TextEncoder().encode(codeVerifier);
-    const digest = await window.crypto.subtle.digest('SHA-256', data);
-    return btoa(String.fromCharCode.apply(null, [...new Uint8Array(digest)]))
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=+$/, '');
-}
-
-async function handleCallback() {
+  async handleCallback(): Promise<void> {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
-    if (code) {
-        const token = await getAccessToken(SPOTIFY_CLIENT_ID, code);
-        const profile = await fetchProfile(token);
-        localStorage.setItem("spotify-profile", JSON.stringify(profile));
-        window.history.replaceState({}, document.title, "/");
-    }
-}
+    if (!code) return;
 
-async function getAccessToken(clientId: string, code: string): Promise<string> {
+    const token = await this.getAccessToken(SPOTIFY_CLIENT_ID, code);
+    const profile = await this.fetchProfile(token);
+    localStorage.setItem("spotify-profile", JSON.stringify(profile));
+    window.history.replaceState({}, document.title, "/");
+  }
+
+  private generateCodeVerifier(length: number): string {
+    const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let text = "";
+
+    for (let i = 0; i < length; i += 1) {
+      text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+
+    return text;
+  }
+
+  private async generateCodeChallenge(codeVerifier: string): Promise<string> {
+    const data = new TextEncoder().encode(codeVerifier);
+    const digest = await window.crypto.subtle.digest("SHA-256", data);
+    return btoa(String.fromCharCode(...new Uint8Array(digest)))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  }
+
+  private async getAccessToken(clientId: string, code: string): Promise<string> {
     const verifier = sessionStorage.getItem("spotify_verifier");
 
     const params = new URLSearchParams();
@@ -55,29 +58,32 @@ async function getAccessToken(clientId: string, code: string): Promise<string> {
     params.append("grant_type", "authorization_code");
     params.append("code", code);
     params.append("redirect_uri", `${APP_FULL_URL}/callback/spotify`);
-    params.append("code_verifier", verifier!);
+    params.append("code_verifier", verifier ?? "");
 
     const result = await fetch("https://accounts.spotify.com/api/token", {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: params
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params,
     });
 
-    const { access_token } = await result.json();
-    return access_token;
-}
+    const { access_token: accessToken } = await result.json();
+    return accessToken;
+  }
 
-async function fetchProfile(token: string): Promise<any> {
+  private async fetchProfile(token: string): Promise<any> {
     const result = await fetch("https://api.spotify.com/v1/me", {
-        method: "GET", headers: { Authorization: `Bearer ${token}` }
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
     });
 
-    return await result.json();
+    return result.json();
+  }
 }
 
-export {
-    getAccessToken as getSpotifyAccessToken,
-    fetchProfile as fetchSpotifyProfile,
-    redirectToOAuth as redirectToSpotifyOAuth,
-    handleCallback as handleSpotifyCallback
-};
+export const spotifyOAuthClient = new SpotifyOAuthClient();
+
+export const redirectToSpotifyOAuth = (): Promise<void> =>
+  spotifyOAuthClient.redirectToOAuth();
+export const handleSpotifyCallback = (): Promise<void> =>
+  spotifyOAuthClient.handleCallback();
+

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -1,8 +1,9 @@
 import AppleLogo from "../assets/provider/applemusic.svg";
 import SpotifyLogo from "../assets/provider/spotify.png";
 import SoundCloudLogo from "../assets/provider/SoundCloud.png";
-import { handleSpotifyCallback, redirectToSpotifyOAuth } from "../handler/spotifyAPI";
-import { handleAppleCallback, redirectToAppleOAuth } from "../handler/appleAPI";
+import { redirectToSpotifyOAuth, handleSpotifyCallback, spotifyOAuthClient } from "../handler/spotifyAPI";
+import { redirectToAppleOAuth, handleAppleCallback, appleMusicOAuthClient } from "../handler/appleAPI";
+import type { IPlatformOAuthClient } from "../handler/IPlatformOAuthClient";
 
 enum Platform {
     SPOTIFY = "spotify",
@@ -18,6 +19,7 @@ interface PlatformInfo {
     OAuthFunction?: () => Promise<void>;
     CallbackFunction?: () => Promise<void>;
     scopes?: string[];
+    oauthClient?: IPlatformOAuthClient;
 }
 
 const PLATFORMS: Record<Platform, PlatformInfo> = {
@@ -28,6 +30,7 @@ const PLATFORMS: Record<Platform, PlatformInfo> = {
         logo: SpotifyLogo,
         OAuthFunction: redirectToSpotifyOAuth,
         CallbackFunction: handleSpotifyCallback,
+        oauthClient: spotifyOAuthClient,
         scopes: [
             "user-read-private",
             "user-read-email"
@@ -39,7 +42,8 @@ const PLATFORMS: Record<Platform, PlatformInfo> = {
         loginLabel: "Sign in with Apple",
         logo: AppleLogo,
         OAuthFunction: redirectToAppleOAuth,
-        CallbackFunction: handleAppleCallback
+        CallbackFunction: handleAppleCallback,
+        oauthClient: appleMusicOAuthClient,
     },
     [Platform.SOUNDCLOUD]: {
         id: Platform.SOUNDCLOUD,
@@ -55,6 +59,7 @@ const getPlatformLogo = (p: Platform): string => PLATFORMS[p].logo;
 const getPlatformDisplayName = (p: Platform): string => PLATFORMS[p].displayName;
 const getPlatformOAuthFunction = (p: Platform): (() => Promise<void>) | undefined => PLATFORMS[p].OAuthFunction;
 const getPlatformCallbackFunction = (p: Platform): (() => Promise<void>) | undefined => PLATFORMS[p].CallbackFunction;
+const getPlatformOAuthClient = (p: Platform): IPlatformOAuthClient | undefined => PLATFORMS[p].oauthClient;
 
 export default Platform;
 export {
@@ -62,5 +67,6 @@ export {
     getPlatformLogo,
     getPlatformDisplayName,
     getPlatformOAuthFunction,
-    getPlatformCallbackFunction
+    getPlatformCallbackFunction,
+    getPlatformOAuthClient
 }


### PR DESCRIPTION
## Summary
- connect playlist sections directly to platform clients so fetching, caching, and status updates stay near the UI
- formalize OAuth handling with reusable client classes and expose them through the platform metadata
- tighten platform client interfaces and Spotify mapping to return typed playlist data while preserving pending playlist UX

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f54b48984c8329a80291dca655d0b1